### PR TITLE
Implement `Code.Run()` method

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -368,11 +368,6 @@ func ExampleCode_sqrt() {
 }
 
 func compileAndRun[T interface{ []byte | [32]byte }](code Code, callData T) []byte {
-	compiled, err := code.Compile()
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	var slice []byte
 	switch c := any(callData).(type) {
 	case []byte:
@@ -381,7 +376,7 @@ func compileAndRun[T interface{ []byte | [32]byte }](code Code, callData T) []by
 		slice = c[:]
 	}
 
-	got, err := runBytecode(compiled, slice)
+	got, err := code.Run(slice)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/run.go
+++ b/run.go
@@ -1,0 +1,49 @@
+package specialops
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// Run calls c.Compile() and runs the compiled bytecode on a freshly
+// instantiated vm.EVMInterpreter. The default EVM parameters MUST NOT be
+// considered stable: they are currently such that code runs on the Cancun fork
+// with no state DB.
+func (c Code) Run(callData []byte) ([]byte, error) {
+	compiled, err := c.Compile()
+	if err != nil {
+		return nil, fmt.Errorf("%T.Compile(): %v", c, err)
+	}
+	return runBytecode(compiled, callData, false)
+}
+
+func runBytecode(compiled, callData []byte, readOnly bool) ([]byte, error) {
+	interp := vm.NewEVM(
+		vm.BlockContext{
+			BlockNumber: big.NewInt(1),
+			Random:      &common.Hash{}, // non-nil -> post merge
+		},
+		vm.TxContext{},
+		nil, /*statedb*/
+		&params.ChainConfig{
+			LondonBlock: big.NewInt(0),
+			CancunTime:  new(uint64),
+		},
+		vm.Config{},
+	).Interpreter()
+
+	cc := &vm.Contract{
+		Code: compiled,
+		Gas:  30e6,
+	}
+
+	out, err := interp.Run(cc, callData, readOnly)
+	if err != nil {
+		return nil, fmt.Errorf("%T.Run([%T.Compile()], [callData], readOnly=%t): %v", interp, Code{}, readOnly, err)
+	}
+	return out, nil
+}

--- a/run.go
+++ b/run.go
@@ -7,33 +7,32 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/solidifylabs/specialops/runopts"
 )
 
 // Run calls c.Compile() and runs the compiled bytecode on a freshly
 // instantiated vm.EVMInterpreter. The default EVM parameters MUST NOT be
 // considered stable: they are currently such that code runs on the Cancun fork
 // with no state DB.
-func (c Code) Run(callData []byte) ([]byte, error) {
+func (c Code) Run(callData []byte, opts ...runopts.Option) ([]byte, error) {
 	compiled, err := c.Compile()
 	if err != nil {
 		return nil, fmt.Errorf("%T.Compile(): %v", c, err)
 	}
-	return runBytecode(compiled, callData, false)
+	return runBytecode(compiled, callData, opts...)
 }
 
-func runBytecode(compiled, callData []byte, readOnly bool) ([]byte, error) {
+func runBytecode(compiled, callData []byte, opts ...runopts.Option) ([]byte, error) {
+	cfg, err := newRunConfig(opts...)
+	if err != nil {
+		return nil, err
+	}
 	interp := vm.NewEVM(
-		vm.BlockContext{
-			BlockNumber: big.NewInt(1),
-			Random:      &common.Hash{}, // non-nil -> post merge
-		},
-		vm.TxContext{},
-		nil, /*statedb*/
-		&params.ChainConfig{
-			LondonBlock: big.NewInt(0),
-			CancunTime:  new(uint64),
-		},
-		vm.Config{},
+		cfg.BlockCtx,
+		cfg.TxCtx,
+		cfg.StateDB,
+		cfg.ChainConfig,
+		cfg.VMConfig,
 	).Interpreter()
 
 	cc := &vm.Contract{
@@ -41,9 +40,28 @@ func runBytecode(compiled, callData []byte, readOnly bool) ([]byte, error) {
 		Gas:  30e6,
 	}
 
-	out, err := interp.Run(cc, callData, readOnly)
+	out, err := interp.Run(cc, callData, cfg.ReadOnly)
 	if err != nil {
-		return nil, fmt.Errorf("%T.Run([%T.Compile()], [callData], readOnly=%t): %v", interp, Code{}, readOnly, err)
+		return nil, fmt.Errorf("%T.Run([%T.Compile()], [callData], readOnly=%t): %v", interp, Code{}, cfg.ReadOnly, err)
 	}
 	return out, nil
+}
+
+func newRunConfig(opts ...runopts.Option) (*runopts.Configuration, error) {
+	cfg := &runopts.Configuration{
+		BlockCtx: vm.BlockContext{
+			BlockNumber: big.NewInt(0),
+			Random:      &common.Hash{}, // post merge
+		},
+		ChainConfig: &params.ChainConfig{
+			LondonBlock: big.NewInt(0),
+			CancunTime:  new(uint64),
+		},
+	}
+	for _, o := range opts {
+		if err := o.Apply(cfg); err != nil {
+			return nil, fmt.Errorf("runopts.Option[%T].Apply(): %v", o, err)
+		}
+	}
+	return cfg, nil
 }

--- a/runopts/runopts.go
+++ b/runopts/runopts.go
@@ -1,0 +1,44 @@
+// Package runopts provides configuration options for specialops.Code.Run().
+package runopts
+
+import (
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// A Configuration carries all values that can be modified to configure a call
+// to specialops.Code.Run(). It is intially set by Run() and then passed to all
+// Options to be modified.
+type Configuration struct {
+	// vm.NewEVM()
+	BlockCtx    vm.BlockContext
+	TxCtx       vm.TxContext
+	StateDB     vm.StateDB
+	ChainConfig *params.ChainConfig
+	VMConfig    vm.Config
+	// EVMInterpreter.Run()
+	ReadOnly bool // static call
+}
+
+// An Option modifies a Configuration.
+type Option interface {
+	Apply(*Configuration) error
+}
+
+// A FuncOption converts any function into an Option by calling itself as
+// Apply().
+type FuncOption func(*Configuration) error
+
+// Apply returns f(c).
+func (f FuncOption) Apply(c *Configuration) error {
+	return f(c)
+}
+
+// ReadOnly sets the `readOnly` argument to true when calling
+// EVMInterpreter.Run(), equivalent to a static call.
+func ReadOnly() Option {
+	return FuncOption(func(c *Configuration) error {
+		c.ReadOnly = true
+		return nil
+	})
+}

--- a/specialops_test.go
+++ b/specialops_test.go
@@ -14,7 +14,7 @@ import (
 // error, otherwise returning the result. It's useful for testable examples that
 // don't have access to t.Fatal().
 func mustRunByteCode(compiled, callData []byte) []byte {
-	out, err := runBytecode(compiled, callData, false)
+	out, err := runBytecode(compiled, callData)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Calls `Code.Compile()` and then [Run()s](https://pkg.go.dev/github.com/ethereum/go-ethereum/core/vm#EVMInterpreter.Run) the compiled bytecode. Includes the `runopts` package to configure calls to `Run()` without polluting the `specialops` namespace for those who dot-import the package.