### PR TITLE
Reduced footprint of exported symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 # IDEs
-
 workspace.code-workspace
+
+# Scratchpad
+experimental/**
+
+# Coverage
+cover.out
+lcov.info

--- a/compile.go
+++ b/compile.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/core/vm"
+
+	"github.com/solidifylabs/specialops/types"
 )
 
 // A splice is a (possibly empty) buffer of bytecode, followed by either a
@@ -13,7 +15,7 @@ import (
 // determine. A splice allows for lazy determination of locations.
 type splice struct {
 	buf bytes.Buffer
-	op  Bytecoder // either JUMPDEST or PUSHJUMPDEST
+	op  types.Bytecoder // either JUMPDEST or PUSHJUMPDEST
 	// If op is a JUMPDEST
 	offset *int // Current estimate of offset in the bytecode, or nil if not yet estimated
 	// If op is a PUSHJUMPDEST
@@ -43,7 +45,7 @@ func (s *spliceConcat) curr() *splice {
 // to the previous splice.
 func newSpliceBuffer[T interface{ JUMPDEST | PUSHJUMPDEST }](s *spliceConcat, op T) *bytes.Buffer {
 	curr := s.curr()
-	curr.op = Bytecoder(op)
+	curr.op = types.Bytecoder(op)
 	if j, ok := any(op).(JUMPDEST); ok {
 		s.dests[j] = curr
 	}
@@ -59,7 +61,7 @@ func (c Code) flatten() Code {
 	out := make(Code, 0, len(c))
 	for _, bc := range c {
 		switch bc := bc.(type) {
-		case BytecodeHolder:
+		case types.BytecodeHolder:
 			out = append(out, Code(bc.Bytecoders()).flatten()...)
 		default:
 			out = append(out, bc)

--- a/specialops_test.go
+++ b/specialops_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/holiman/uint256"
+	"github.com/solidifylabs/specialops/types"
 )
 
 // mustRunByteCode propagates arguments to runBytecode, calling log.Fatal() on
@@ -203,7 +204,7 @@ func TestRunCompiled(t *testing.T) {
 	}
 }
 
-func bytecode(t *testing.T, b Bytecoder) []byte {
+func bytecode(t *testing.T, b types.Bytecoder) []byte {
 	t.Helper()
 	buf, err := b.Bytecode()
 	if err != nil {
@@ -225,7 +226,7 @@ func TestPUSHBytesZeroes(t *testing.T) {
 	})
 
 	t.Run("various types zero", func(t *testing.T) {
-		for _, b := range []Bytecoder{
+		for _, b := range []types.Bytecoder{
 			PUSH(int(0)),
 			PUSH(uint64(0)),
 			PUSH(common.Address{}),

--- a/specialops_test.go
+++ b/specialops_test.go
@@ -213,7 +213,7 @@ func bytecode(t *testing.T, b types.Bytecoder) []byte {
 	return buf
 }
 
-func TestPUSHBytesZeroes(t *testing.T) {
+func TestPUSHZeroes(t *testing.T) {
 	push0 := []byte{byte(vm.PUSH0)}
 
 	t.Run("all-zero bytes", func(t *testing.T) {

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,63 @@
+// Package types defines types used by the specialops package, which is intended
+// to be dot-imported so requires a minimal footprint of exported symbols.
+package types
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+// A Bytecoder returns raw EVM bytecode. If the returned bytecode is the
+// concatenation of multiple Bytecoder outputs, the type MUST also implement
+// BytecodeHolder.
+type Bytecoder interface {
+	Bytecode() ([]byte, error)
+}
+
+// A BytecodeHolder is a concatenation of Bytecoders.
+type BytecodeHolder interface {
+	Bytecoder
+	Bytecoders() []Bytecoder
+}
+
+// A StackPusher returns [1,32] bytes to be pushed to the stack.
+type StackPusher interface {
+	ToPush() []byte
+}
+
+// BytecoderFromStackPusher returns a Bytecoder that calls s.ToPush() and
+// prepends the appropriate PUSH<N> opcode to the returned bytecode.
+func BytecoderFromStackPusher(s StackPusher) Bytecoder {
+	return pusher{s}
+}
+
+type pusher struct {
+	StackPusher
+}
+
+func (p pusher) Bytecode() ([]byte, error) {
+	buf := p.ToPush()
+	n := len(buf)
+	if n == 0 || n > 32 {
+		return nil, fmt.Errorf("len(%T.ToPush()) == %d must be in [1,32]", p.StackPusher, n)
+	}
+
+	size := n
+	for _, b := range buf {
+		if b == 0 {
+			size--
+		} else {
+			break
+		}
+	}
+	if size == 0 {
+		return []byte{byte(vm.PUSH0)}, nil
+	}
+
+	return append(
+		// PUSH0 to PUSH32 are contiguous, so we can perform arithmetic on them.
+		[]byte{byte(vm.PUSH0 + vm.OpCode(size))},
+		buf[n-size:]...,
+	), nil
+}


### PR DESCRIPTION
`specialops` needs to be dot-imported, promoting all exported symbols into the importing package, allowing the syntax to feel like a regular language. The footprint of exported symbols should therefore be kept to a minimum, including only those needed to write code (we should call them "specs").

This PR therefore moves type-defining symbols and related functionality into a different package.

Also includes minor chores:
1. gitignore morefiles
2. Make a test name more precise