### PR TITLE
test: add tests of paths that are impossible with regular usage

### DIFF
--- a/specialops.go
+++ b/specialops.go
@@ -66,14 +66,15 @@ func (o opCode) String() string {
 	return vm.OpCode(o).String()
 }
 
-// A JUMPDEST is a Bytecoder that always returns vm.JUMPDEST while also storing
-// its location in the bytecode for use via a PUSHJUMPDEST or
+// A JUMPDEST is a Bytecoder that is converted into a vm.JUMPDEST while also
+// storing its location in the bytecode for use via a PUSHJUMPDEST or
 // PUSH[string|JUMPDEST](<lbl>).
 type JUMPDEST string
 
-// Bytecode returns []byte{vm.JUMPDEST}.
+// Bytecode always returns an error as PUSHJUMPDEST values have special handling
+// inside Code.Compile().
 func (j JUMPDEST) Bytecode() ([]byte, error) {
-	return []byte{byte(vm.JUMPDEST)}, nil
+	return nil, fmt.Errorf("direct call to %T.Bytecode()", j)
 }
 
 // PUSHJUMPDEST pushes the bytecode location of the respective JUMPDEST.

--- a/specialops_test.go
+++ b/specialops_test.go
@@ -258,3 +258,22 @@ func TestPUSHZeroes(t *testing.T) {
 		}
 	})
 }
+
+func TestNoCallBytecode(t *testing.T) {
+	// Some special Bytecoder implementations are only compiler hints and should
+	// never have their Bytecode() method called. This artificially reduces test
+	// coverage because they're impossible paths, and this test addresses that.
+
+	for _, b := range []types.Bytecoder{
+		Code{},
+		JUMPDEST(""),
+		PUSHJUMPDEST(""),
+		ExpectStackDepth(0),
+		SetStackDepth(0),
+		Inverted(0),
+	} {
+		if _, err := b.Bytecode(); err == nil {
+			t.Errorf("Special Bytecoder %T.Bytecode() returned non-nil error", b)
+		}
+	}
+}


### PR DESCRIPTION
Some special `types.Bytecoder` implementations are only compiler hints and should never have their `Bytecode()` method called. This artificially reduces test coverage because they're impossible paths, and this PR addresses that.