### PR TITLE
fix: `Debugger` error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ bytecode unchanged.
 - [x] Compiler-state assertions (e.g. expected stack depth)
 - [ ] Automatic stack permutation
 - [ ] Standalone compiler
-- [x] In-process EVM execution
+- [x] In-process EVM execution (geth)
 - [x] Debugger
   * [x] Stepping
   * [ ] Breakpoints
@@ -38,6 +38,8 @@ bytecode unchanged.
     * [x] Memory
     * [x] Stack
   * [ ] User interface
+- [ ] Source mapping
+- [ ] Coverage analysis
 - [ ] Fork testing with RPC URL
 
 ### Documentation
@@ -87,7 +89,7 @@ state := dbg.State() // is updated on calls to Step() / FastForward()
 
 for !dbg.Done() {
   dbg.Step()
-  fmt.Println("Peek-a-boo", state.CopeContext.Stack().Back(0))
+  fmt.Println("Peek-a-boo", state.ScopeContext.Stack().Back(0))
 }
 
 result, err := results()

--- a/README.md
+++ b/README.md
@@ -69,9 +69,29 @@ code := Code{
     Fn(RETURN, PUSH(32-len(hello)), PUSH(len(hello))),
 }
 
+// ----- COMPILE -----
 bytecode, err := code.Compile()
-// or
-result, err := code.Run(nil /*callData*/)
+// ...
+
+// ----- EXECUTE -----
+
+result, err := code.Run(nil /*callData*/ /*, [runopts.Options]...*/)
+// ...
+
+// ----- DEBUG (Programmatic) -----
+
+dbg, results := code.StartDebugging(nil /*callData*/ /*, Options...*/)
+defer dbg.FastForward() // best practice to avoid resource leaks
+
+state := dbg.State() // is updated on calls to Step() / FastForward()
+
+for !dbg.Done() {
+  dbg.Step()
+  fmt.Println("Peek-a-boo", state.CopeContext.Stack().Back(0))
+}
+
+result, err := results()
+//...
 ```
 
 ### Other examples

--- a/compile.go
+++ b/compile.go
@@ -152,6 +152,10 @@ CodeLoop:
 
 		case PUSHJUMPDEST:
 
+		case Raw:
+			code, _ := use.Bytecode() // always returns nil error
+			buf.Write(code)
+
 		default:
 			code, err := use.Bytecode()
 			if err != nil {

--- a/specialops.go
+++ b/specialops.go
@@ -66,6 +66,15 @@ func (o opCode) String() string {
 	return vm.OpCode(o).String()
 }
 
+// Raw is a Bytecoder that bypasses all compiler checks and simply appends its
+// contents to bytecode. It can be used for raw data, not meant to be executed.
+type Raw []byte
+
+// Bytecode returns `r` unchanged, and a nil error.
+func (r Raw) Bytecode() ([]byte, error) {
+	return []byte(r), nil
+}
+
 // A JUMPDEST is a Bytecoder that is converted into a vm.JUMPDEST while also
 // storing its location in the bytecode for use via a PUSHJUMPDEST or
 // PUSH[string|JUMPDEST](<lbl>).


### PR DESCRIPTION
The value in `Debugger.State().Err` SHOULD be checked once `Done()` returns true. It is also available by unwrapping the error returned by the results function from `Code.StartDebugging()`.